### PR TITLE
fix: Fix validation API now accepts more emails

### DIFF
--- a/app/src/pages/auth/RegisterCandidate.jsx
+++ b/app/src/pages/auth/RegisterCandidate.jsx
@@ -424,7 +424,7 @@ export default function RegisterCandidate() {
 					boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.3)',
 					backdropFilter: 'blur(8px)',
 					borderWidth: '1px',
-					overflow: 'auto', 
+					overflow: 'auto',
 				}}>
 				<h2
 					className='text-2xl font-bold text-center mb-4 text-white'

--- a/app/src/pages/auth/RegisterCandidate.jsx
+++ b/app/src/pages/auth/RegisterCandidate.jsx
@@ -218,6 +218,8 @@ export default function RegisterCandidate() {
 
 	async function handleSubmit(e) {
 		e.preventDefault()
+		setErrors({})
+
 		if (!isCheckboxChecked) {
 			setErrors({ termsCheckbox: 'You must read and accept the terms and conditions' })
 			return
@@ -261,6 +263,7 @@ export default function RegisterCandidate() {
 			setLoading(false)
 			if (!isValidEmail) {
 				setEmailValid(false)
+				setErrors({ email: 'Please use a valid email' })
 				return
 			}
 		}
@@ -333,7 +336,7 @@ export default function RegisterCandidate() {
 
 		try {
 			const response = await axios.request(options)
-			if (response.data.status === 'valid') {
+			if (response.data.status !== 'invalid' && response.data.reason !== 'dns_error') {
 				return true
 			} else {
 				return false
@@ -515,7 +518,9 @@ export default function RegisterCandidate() {
 							isMandatory
 						/>
 						{loading && <p className='text-white'>Validating email...</p>}
-						{!emailValid && <p className='text-red-500'>Please use a real email.</p>}
+						{errors.corporativeMail && (
+							<p className='text-red-500'>{errors.corporativeMail}</p>
+						)}
 						<FormTextInput
 							labelFor='Phonenumber'
 							labelText='Phone number'

--- a/app/src/pages/auth/RegisterRepresentative.jsx
+++ b/app/src/pages/auth/RegisterRepresentative.jsx
@@ -189,6 +189,7 @@ export default function RegisterRepresentative() {
 	async function handleSubmit(e) {
 		e.preventDefault()
 		setEmailValid(true)
+		setErrors({})
 
 		if (!isCheckboxChecked) {
 			setErrors({ termsCheckbox: 'You must read and accept the terms and conditions' })
@@ -224,6 +225,7 @@ export default function RegisterRepresentative() {
 			setLoading(false)
 			if (!isValidEmail) {
 				setEmailValid(false)
+				setErrors({corporativeMail: 'Please use a real email'})
 				return
 			}
 		}
@@ -293,7 +295,7 @@ export default function RegisterRepresentative() {
 
 		try {
 			const response = await axios.request(options)
-			if (response.data.status === 'valid') {
+			if (response.data.status !== 'invalid' && response.data.reason !== 'dns_error') {
 				return true
 			} else {
 				return false
@@ -437,7 +439,6 @@ export default function RegisterRepresentative() {
 							isMandatory
 						/>
 						{loading && <p className='text-white'>Validating email...</p>}
-						{!emailValid && <p className='text-red-500'>Please use a real email.</p>}
 						{errors.corporativeMail && (
 							<p className='text-red-500'>{errors.corporativeMail}</p>
 						)}

--- a/app/src/pages/auth/RegisterRepresentative.jsx
+++ b/app/src/pages/auth/RegisterRepresentative.jsx
@@ -225,7 +225,7 @@ export default function RegisterRepresentative() {
 			setLoading(false)
 			if (!isValidEmail) {
 				setEmailValid(false)
-				setErrors({corporativeMail: 'Please use a real email'})
+				setErrors({ corporativeMail: 'Please use a real email' })
 				return
 			}
 		}


### PR DESCRIPTION
**Trabajo realizado:**

- Reducción del criterio de la validación de correo para aceptar más correos.
- Prueba con correos: @us.es, @outlook.com, @gmail.com, @hotmail.com.
- Cambio en la forma de mostrar aviso de error de validación (antes no se borraba el texto de error nunca).
